### PR TITLE
Check for non-existent node in get_node_data() (Fix #41)

### DIFF
--- a/src/middle/ssa/ssastorage.rs
+++ b/src/middle/ssa/ssastorage.rs
@@ -625,6 +625,10 @@ impl SSA for SSAStorage {
     }
 
     fn get_node_data(&self, i: &NodeIndex) -> Result<TNodeData, Box<Debug>> {
+        if (!self.g.contains_node(*i)) {
+            return Err(Box::new("Node does not exist"));
+        }
+
         match self.g[*i] {
             NodeData::Op(opc, vt) => Ok(TNodeData {
                 vt: vt,


### PR DESCRIPTION
The issue at #41 occurs occasionally when a node is removed by **try_remove_trivial_phi()**. Since it's recursive, it's possible for a node to be removed while also still in the queue to be processed. When **get_node_data()** is called on a node that has already been removed, minidec panics. 

My fix was to just put a check in **get_node_data()** before the match to make sure the node exists. I don't know if this is the optimal solution so let me know if there's something else I should be doing.
