### PR TITLE
Adds extern crate r2api usage in test files

### DIFF
--- a/tests/bin_ls_test.rs
+++ b/tests/bin_ls_test.rs
@@ -2,6 +2,7 @@
 
 #[macro_use] extern crate radeco_lib;
 extern crate r2pipe;
+extern crate r2api;
 extern crate serde_json;
 
 use std::fs::File;

--- a/tests/complete_test1.rs
+++ b/tests/complete_test1.rs
@@ -55,6 +55,7 @@
 
 #[macro_use] extern crate radeco_lib;
 extern crate r2pipe;
+extern crate r2api;
 extern crate serde_json;
 
 use std::fs::File;


### PR DESCRIPTION
This should run the test suite. I don't think any tests should break due to these changes since they only modify the API used.