### PR TITLE
switched command line parsing to clap, and implemented syntax highlig…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,14 @@ default = []
 trace_log = ["radeco-lib/trace_log"]
 
 [dependencies]
-docopt = "*"
 rustc-serialize = "*"
 log = "*"
 base64 = "0.9.2"
 rustyline = "2.0.0"
+lazy_static = "1.2.0"
+clap = "2.32.0"
+syntect = "3.0"
+
 
 [dependencies.r2pipe]
 # path = "../r2pipe.rs"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,29 +1,23 @@
-extern crate docopt;
-
-use self::docopt::{Docopt, Error};
+use clap::{Arg, App};
 use std::process;
 
-pub fn parse_args(usage: &str) -> (Option<String>, bool, bool) {
-    let s = Some(env!("VERSION_STR").to_string());
-    let args = Docopt::new(usage).and_then(|d| d.help(true).version(s).parse());
-    match args {
-        Err(Error::WithProgramUsage(box Error::Help, ref msg)) | Err(Error::Version(ref msg)) => {
-            println!("{}", msg);
-            process::exit(0)
-        }
-        Ok(a) => {
-            let is_append = a.get_bool("--append");
-            let is_batch = a.get_bool("--batch");
-            let bin = match a.get_str("<bin>") {
-                "" => None,
-                s => Some(s.to_string()),
-            };
-            if is_batch && bin.is_some() {
-                eprintln!("Pass a binary for batch mode");
-                process::exit(0);
-            }
-            (bin, is_append, is_batch)
-        }
-        _ => (None, false, false),
+pub fn parse_args() -> (Option<String>, bool, bool, bool) {
+    let vs = env!("VERSION_STR");
+    let matches = App::new("radeco").version(vs)
+                .arg(Arg::with_name("BIN")
+                    .help("Binary to load")
+                    .required(false))
+                .arg(Arg::from_usage("-a --append 'Append separator to the end of every output.'"))
+                .arg(Arg::from_usage("-b --batch 'Decompile the whole binary'"))
+                .arg(Arg::from_usage("-l --highlight 'Use syntax highlight on output'"))
+                .get_matches();
+    let is_append = matches.is_present("append");
+    let is_batch = matches.is_present("batch");
+    let is_highlight = matches.is_present("highlight");
+    let bin = matches.value_of("BIN").map(|s| s.to_string());
+    if is_batch && bin.is_none() {
+        eprintln!("Pass a binary for batch mode");
+        process::exit(0);
     }
+    (bin, is_append, is_batch, is_highlight)
 }

--- a/src/highlighting.rs
+++ b/src/highlighting.rs
@@ -1,0 +1,23 @@
+use syntect::easy::HighlightLines;
+use syntect::parsing::SyntaxSet;
+use syntect::highlighting::{ThemeSet, Style};
+use syntect::util::{as_24_bit_terminal_escaped, LinesWithEndings};
+
+lazy_static! {
+	static ref SYNTAX_SET : SyntaxSet = {
+		SyntaxSet::load_defaults_newlines()
+	};
+	static ref THEME_SET: ThemeSet = {
+		ThemeSet::load_defaults()
+	};
+}
+
+pub fn print_highlighted(code : &str) {
+	let syntax = SYNTAX_SET.find_syntax_by_extension("rs").unwrap();
+	let mut h = HighlightLines::new(syntax, &THEME_SET.themes["base16-ocean.dark"]);
+	for line in LinesWithEndings::from(code) {
+	    let ranges: Vec<(Style, &str)> = h.highlight(line, &SYNTAX_SET);
+	    let escaped = as_24_bit_terminal_escaped(&ranges[..], true);
+	    println!("{}", escaped);
+	}
+}


### PR DESCRIPTION
…hting

I switched the command line parsing to the better clap crate and implemented some syntax highlighting using syntect.

I tested this on linux since color terminal there are usually better supported I think, anyway it's optional by specifying a flag

![image](https://user-images.githubusercontent.com/1010159/49332178-6efa2c00-f5a8-11e8-87f3-a9563d194d15.png)
