### PR TITLE
Remove custom_attribute feature

### DIFF
--- a/radeco-lib/src/lib.rs
+++ b/radeco-lib/src/lib.rs
@@ -42,7 +42,6 @@
 #![feature(box_syntax)]
 #![feature(slice_patterns)]
 #![feature(try_trait)]
-#![feature(custom_attribute)]
 //#[cfg(test)] #[macro_use] extern crate quickcheck_macros;
 
 extern crate petgraph;


### PR DESCRIPTION
This has been removed from rust.
After removing the line, it compiles fine with my `rustc 1.43.0-nightly (58b834344 2020-02-05)`
Otherwise fails with:
```
error[E0557]: feature has been removed
  --> radeco-lib/src/lib.rs:45:12
   |
45 | #![feature(custom_attribute)]
   |            ^^^^^^^^^^^^^^^^ feature has been removed
   |
   = note: removed in favor of `#![register_tool]` and `#![register_attr]`
```